### PR TITLE
add support for super column

### DIFF
--- a/target_redshift/db_sync.py
+++ b/target_redshift/db_sync.py
@@ -45,8 +45,7 @@ def column_type(schema_property, with_length=True):
     if schema_property.get("maxLength", 0) > varchar_length:
         varchar_length = LONG_VARCHAR_LENGTH
     if "object" in property_type or "array" in property_type:
-        column_type = "character varying"
-        varchar_length = LONG_VARCHAR_LENGTH
+        column_type = "super"
 
     # Every date-time JSON value is currently mapped to TIMESTAMP WITHOUT TIME ZONE
     #
@@ -78,12 +77,13 @@ def column_type(schema_property, with_length=True):
 
 
 def column_trans(schema_property):
-    property_type = schema_property["type"]
-    column_trans = ""
-    if "object" in property_type or "array" in property_type:
-        column_trans = "parse_json"
-
-    return column_trans
+    return ""
+#    property_type = schema_property["type"]
+#    column_trans = ""
+#    if "object" in property_type or "array" in property_type:
+#        column_trans = "parse_json"
+#
+#    return column_trans
 
 
 def safe_column_name(name):

--- a/tests/unit/test_db_sync.py
+++ b/tests/unit/test_db_sync.py
@@ -84,8 +84,8 @@ class TestTargetRedshift(object):
         assert mapper(json_int)          == 'numeric'
         assert mapper(json_int_or_str)   == 'character varying(65535)'
         assert mapper(json_bool)         == 'boolean'
-        assert mapper(json_obj)          == 'character varying(65535)'
-        assert mapper(json_arr)          == 'character varying(65535)'
+        assert mapper(json_obj)          == 'super'
+        assert mapper(json_arr)          == 'super'
 
 
     def test_stream_name_to_dict(self):


### PR DESCRIPTION
Redshift now supports SUPER values up to 16MB, making it a better option for objects and arrays than VARCHAR